### PR TITLE
Migrate all frontend colors to CSS variables from globals.css

### DIFF
--- a/src/app/(themed)/IndexComponents/NavBar.tsx
+++ b/src/app/(themed)/IndexComponents/NavBar.tsx
@@ -79,8 +79,8 @@ export default function NavBar() {
         {/* Weather display with entry animation */}
         {isLoadingWeather ? (
           <div className="flex items-center space-x-2">
-            <div className="w-8 h-8 bg-gray-300 dark:bg-gray-700 rounded animate-pulse"></div>
-            <div className="w-32 h-4 bg-gray-300 dark:bg-gray-700 rounded animate-pulse"></div>
+            <div className="w-8 h-8 rounded animate-pulse" style={{ backgroundColor: 'var(--skeleton-bg)' }}></div>
+            <div className="w-32 h-4 rounded animate-pulse" style={{ backgroundColor: 'var(--skeleton-bg)' }}></div>
           </div>
         ) : weather ? (
           <motion.div

--- a/src/app/(themed)/IndexComponents/PrayerTimeTable.tsx
+++ b/src/app/(themed)/IndexComponents/PrayerTimeTable.tsx
@@ -42,10 +42,10 @@ type TableTimes = Omit<RawPrayerTimes, 'sunrise'>
 function TableSkeleton() {
   return (
     <div className="animate-pulse">
-      <div className="h-8 bg-gray-300 dark:bg-gray-700 rounded w-3/4 mx-auto mb-4"></div>
+      <div className="h-8 rounded w-3/4 mx-auto mb-4" style={{ backgroundColor: 'var(--skeleton-bg)' }}></div>
       <div className="space-y-2">
         {[1, 2, 3, 4, 5].map((i) => (
-          <div key={i} className="h-12 bg-gray-300 dark:bg-gray-700 rounded"></div>
+          <div key={i} className="h-12 rounded" style={{ backgroundColor: 'var(--skeleton-bg)' }}></div>
         ))}
       </div>
     </div>

--- a/src/app/(themed)/IndexComponents/PrayerTimeline.tsx
+++ b/src/app/(themed)/IndexComponents/PrayerTimeline.tsx
@@ -139,7 +139,7 @@ export default function PrayerTimeline() {
   if (isLoading || !range) {
     return (
       <div className="animate-pulse py-12">
-        <div className="h-16 bg-gray-300 dark:bg-gray-700 rounded"></div>
+        <div className="h-16 rounded" style={{ backgroundColor: 'var(--skeleton-bg)' }}></div>
       </div>
     )
   }
@@ -237,7 +237,7 @@ export default function PrayerTimeline() {
         </div>
       </div>
 
-      <p className="text-center text-sm text-gray-600 mt-4">
+      <p className="text-center text-sm mt-4" style={{ color: 'var(--text-muted)' }}>
         • Maghrib and Isha are prayed at the Athaan (no separate jamaʿāh time)
       </p>
 

--- a/src/app/display/Components/DowntimeDisplay.tsx
+++ b/src/app/display/Components/DowntimeDisplay.tsx
@@ -178,7 +178,7 @@ export default function DowntimeDisplay() {
       <div
         className="absolute inset-0 pointer-events-none"
         style={{
-          background: 'rgba(0, 0, 0, 0.3)',
+          background: 'var(--overlay-dark)',
         }}
       />
 

--- a/src/app/display/Components/PrayerOverlay.tsx
+++ b/src/app/display/Components/PrayerOverlay.tsx
@@ -201,15 +201,9 @@ const PrayerOverlay = memo(function PrayerOverlay() {
               z-index: 50;
             }
 
-            /* Light mode: light blur overlay */
+            /* Theme-aware blur overlay - uses CSS variables */
             .overlay-root {
-              background: rgba(245, 228, 211, 0.85);
-              backdrop-filter: blur(20px);
-            }
-
-            /* Dark mode: dark blur overlay */
-            html.dark .overlay-root {
-              background: rgba(21, 49, 71, 0.9);
+              background: var(--prayer-overlay-bg);
               backdrop-filter: blur(20px);
             }
 
@@ -235,7 +229,7 @@ const PrayerOverlay = memo(function PrayerOverlay() {
               font-weight: 800;
               line-height: 1;
               color: var(--text-color);
-              text-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+              text-shadow: 0 4px 20px var(--shadow-color);
             }
 
             .countdown-label {
@@ -259,7 +253,7 @@ const PrayerOverlay = memo(function PrayerOverlay() {
               font-weight: 800;
               line-height: 1;
               color: var(--text-color);
-              text-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+              text-shadow: 0 4px 20px var(--shadow-color);
             }
 
             .prayer-status {
@@ -281,16 +275,12 @@ const PrayerOverlay = memo(function PrayerOverlay() {
               align-items: center;
               gap: 1.5rem;
               padding: 1.5rem 2.5rem;
-              background: var(--secondary-color);
+              background: var(--phone-reminder-bg);
               border-radius: 1rem;
               color: var(--text-color);
               font-size: 2.5vh;
               font-weight: 500;
               opacity: 0.95;
-            }
-
-            html.dark .phone-reminder {
-              background: rgba(173, 184, 187, 0.2);
             }
 
             .phone-icon {

--- a/src/app/display/context/DebugContext.tsx
+++ b/src/app/display/context/DebugContext.tsx
@@ -186,13 +186,14 @@ export function DebugProvider({ children }: { children: ReactNode }) {
   };
 
   // Memoized styles to avoid recreating objects on every render
+  // Using CSS variables from globals.css for consistent theming
   const popupBaseStyle = useMemo(() => ({
     position: 'fixed' as const,
     bottom: '2rem',
     left: '50%',
     transform: 'translateX(-50%)',
-    backgroundColor: 'rgba(0, 0, 0, 0.8)',
-    color: 'white',
+    backgroundColor: 'var(--popup-bg)',
+    color: 'var(--static-dark-text-color)',
     padding: '0.75rem 1.5rem',
     borderRadius: '0.5rem',
     fontSize: '1rem',
@@ -214,7 +215,7 @@ export function DebugProvider({ children }: { children: ReactNode }) {
   const helpOverlayStyle = useMemo(() => ({
     position: 'fixed' as const,
     inset: 0,
-    backgroundColor: 'rgba(0, 0, 0, 0.85)',
+    backgroundColor: 'var(--overlay-darkest)',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
@@ -223,12 +224,12 @@ export function DebugProvider({ children }: { children: ReactNode }) {
   }), []);
 
   const helpModalStyle = useMemo(() => ({
-    backgroundColor: '#1a1a1a',
+    backgroundColor: 'var(--modal-bg)',
     borderRadius: '1rem',
     padding: '2rem',
     maxWidth: '500px',
     width: '90%',
-    color: 'white',
+    color: 'var(--static-dark-text-color)',
   }), []);
 
   const helpTitleStyle = useMemo(() => ({
@@ -250,7 +251,7 @@ export function DebugProvider({ children }: { children: ReactNode }) {
   }), []);
 
   const helpKeyStyle = useMemo(() => ({
-    backgroundColor: '#333',
+    backgroundColor: 'var(--modal-bg-secondary)',
     padding: '0.5rem 0.75rem',
     borderRadius: '0.375rem',
     fontFamily: 'monospace',

--- a/src/app/display/page.tsx
+++ b/src/app/display/page.tsx
@@ -120,7 +120,13 @@ function DisplayContent() {
   // Show loading state briefly
   if (isLoading) {
     return (
-      <div className="w-full h-screen flex items-center justify-center bg-black text-white">
+      <div
+        className="w-full h-screen flex items-center justify-center"
+        style={{
+          background: 'linear-gradient(var(--background-start), var(--background-end))',
+          color: 'var(--text-color)',
+        }}
+      >
         <div className="text-2xl opacity-50">Loading...</div>
       </div>
     );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,7 +12,7 @@
   --secondary-color:      #ADB8BB; /* Mist */
   --yellow:               #FFD700; /* Sun accent */
 
-  /*──────────────────────── “x-” Palette (pre-declared dark values) ────────*/
+  /*──────────────────────── "x-" Palette (pre-declared dark values) ────────*/
   --x-background-start:   #153147; /* Navy */
   --x-background-end:     #232A2F; /* Noir */
   --x-text-color:         #F9F8F7; /* Ivory */
@@ -22,7 +22,7 @@
 
   /*────────────────────────── Static Light-mode Vars ───────────────────────
      These never change—even when html.dark overrides the dynamic vars.
-     Use these when you want the “day-palette” hard-locked.
+     Use these when you want the "day-palette" hard-locked.
   ──────────────────────────────────────────────────────────────────────────*/
   --static-light-background-start: #f5e4d3;
   --static-light-background-end:   #F9F8F7;
@@ -33,7 +33,7 @@
 
   /*────────────────────────── Static Dark-mode Vars ────────────────────────
      These never change—even in html.light. Use when you want the
-     “night-palette” hard-locked.
+     "night-palette" hard-locked.
   ──────────────────────────────────────────────────────────────────────────*/
   --static-dark-background-start:  #153147;
   --static-dark-background-end:    #232A2F;
@@ -41,6 +41,65 @@
   --static-dark-accent-color:      #eedecf;
   --static-dark-secondary-color:   #ADB8BB;
   --static-dark-yellow:            #FFD700;
+
+  /*────────────────────────── Status & Semantic Colors ─────────────────────
+     Used for success/error/warning/info states throughout the app.
+  ──────────────────────────────────────────────────────────────────────────*/
+  --status-success:       #16a34a; /* green-600 */
+  --status-success-light: #86efac; /* green-300 */
+  --status-error:         #dc2626; /* red-600 */
+  --status-error-light:   #fca5a5; /* red-300 */
+  --status-warning:       #d97706; /* amber-600 */
+  --status-warning-light: #fcd34d; /* amber-300 */
+  --status-info:          #2563eb; /* blue-600 */
+  --status-info-light:    #93c5fd; /* blue-300 */
+
+  /*────────────────────────── Action Button Colors ─────────────────────────
+     Consistent button colors for primary actions.
+  ──────────────────────────────────────────────────────────────────────────*/
+  --action-primary:       #2563eb; /* blue-600 */
+  --action-primary-hover: #1d4ed8; /* blue-700 */
+  --action-success:       #16a34a; /* green-600 */
+  --action-success-hover: #15803d; /* green-700 */
+  --action-danger:        #dc2626; /* red-600 */
+  --action-danger-hover:  #b91c1c; /* red-700 */
+  --action-cancel:        #6b7280; /* gray-500 */
+  --action-cancel-hover:  #4b5563; /* gray-600 */
+  --button-disabled:      #9ca3af; /* gray-400 */
+
+  /*────────────────────────── Text Variants ────────────────────────────────
+     Secondary and muted text colors.
+  ──────────────────────────────────────────────────────────────────────────*/
+  --text-muted:           #6b7280; /* gray-500 */
+  --text-muted-light:     #9ca3af; /* gray-400 */
+
+  /*────────────────────────── Skeleton Loaders ─────────────────────────────
+     Loading placeholder colors.
+  ──────────────────────────────────────────────────────────────────────────*/
+  --skeleton-bg:          #d1d5db; /* gray-300 */
+  --skeleton-shine:       #e5e7eb; /* gray-200 */
+
+  /*────────────────────────── Overlays & Shadows ───────────────────────────
+     Semi-transparent overlays and shadows.
+  ──────────────────────────────────────────────────────────────────────────*/
+  --overlay-dark:         rgba(0, 0, 0, 0.3);
+  --overlay-darker:       rgba(0, 0, 0, 0.5);
+  --overlay-darkest:      rgba(0, 0, 0, 0.85);
+  --overlay-light:        rgba(255, 255, 255, 0.3);
+  --shadow-color:         rgba(0, 0, 0, 0.2);
+
+  /*────────────────────────── Modal & Popup Colors ─────────────────────────
+     Colors for modals, popups, and tooltips.
+  ──────────────────────────────────────────────────────────────────────────*/
+  --modal-bg:             #1a1a1a;
+  --modal-bg-secondary:   #333333;
+  --popup-bg:             rgba(0, 0, 0, 0.8);
+
+  /*────────────────────────── Prayer Overlay Colors ──────────────────────────
+     Theme-aware overlay backgrounds for prayer countdown/in-progress.
+  ──────────────────────────────────────────────────────────────────────────*/
+  --prayer-overlay-bg:    rgba(245, 228, 211, 0.85); /* Light: Almond with opacity */
+  --phone-reminder-bg:    var(--secondary-color);    /* Uses theme secondary */
 }
 
 /*──────────────────────────────────────────────────────────────────────────
@@ -62,4 +121,16 @@ html.dark {
   --x-accent-color:       #153147;
   --x-secondary-color:    #ADB8BB;
   --x-yellow:             #FFD700;
+
+  /*────────────────────────── Dark-mode Skeleton Loaders ──────────────────*/
+  --skeleton-bg:          #374151; /* gray-700 */
+  --skeleton-shine:       #4b5563; /* gray-600 */
+
+  /*────────────────────────── Dark-mode Text Muted ────────────────────────*/
+  --text-muted:           #9ca3af; /* gray-400 */
+  --text-muted-light:     #6b7280; /* gray-500 */
+
+  /*────────────────────────── Dark-mode Prayer Overlay ───────────────────────*/
+  --prayer-overlay-bg:    rgba(21, 49, 71, 0.9); /* Dark: Navy with opacity */
+  --phone-reminder-bg:    rgba(173, 184, 187, 0.2); /* Mist with transparency */
 }


### PR DESCRIPTION
- Add new CSS variables for status colors, action buttons, text variants, skeleton loaders, overlays, modals, and prayer overlay backgrounds
- Update DebugContext.tsx to use CSS variables for popup/modal styles
- Update PrayerOverlay.tsx to use --prayer-overlay-bg, --phone-reminder-bg, and --shadow-color instead of hardcoded rgba values
- Update DowntimeDisplay.tsx to use --overlay-dark instead of rgba
- Update display/page.tsx loading state to use CSS gradient variables
- Update NavBar, PrayerTimeline, PrayerTimeTable skeleton loaders to use --skeleton-bg CSS variable instead of hardcoded gray colors
- Add dark mode overrides for prayer overlay and skeleton backgrounds